### PR TITLE
feat: migrate to Istio HTTPRoute and fix OIDC group role mapping

### DIFF
--- a/charts/airflow/templates/httproute.yaml
+++ b/charts/airflow/templates/httproute.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.httproute.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: airflow
+spec:
+  parentRefs:
+    - name: {{ .Values.httproute.gateway_name | default "istio-gateway" }}
+      namespace: {{ .Values.httproute.gateway_namespace | default "istio-ingress" }}
+      sectionName: https
+  hostnames:
+    - {{ .Values.httproute.host | quote }}
+  rules:
+    - backendRefs:
+        - name: {{ .Values.httproute.backend_service | default "airflow-webserver" }}
+          port: {{ .Values.httproute.backend_port | default 8080 }}
+{{- end }}

--- a/locals.tf
+++ b/locals.tf
@@ -41,7 +41,7 @@ locals {
       images = {
         airflow = {
           repository = "gersonrs/airflow"
-          tag        = "v1.4.0"
+          tag        = "v1.5.1"
         }
       }
       volumes = [

--- a/locals.tf
+++ b/locals.tf
@@ -119,8 +119,8 @@ locals {
       dags = {
         gitSync = {
           enabled      = true
-          repo         = "git@github.com:GersonRS/airflow-dags.git"
-          branch       = var.target_revision == "develop" ? "develop" : "main"
+          repo         = var.gitsync.repo
+          branch       = var.gitsync.branch
           rev          = "HEAD"
           depth        = 2
           maxFailures  = 2

--- a/locals.tf
+++ b/locals.tf
@@ -208,7 +208,7 @@ locals {
         - name:  AIRFLOW__ASTRO_SDK__XCOM_STORAGE_CONN_ID
           value: "conn_minio_s3"
         - name:  AIRFLOW__ASTRO_SDK__XCOM_STORAGE_URL
-          value: "s3://airflow/xcom/"
+          value: "s3://airflow/xcom"
         - name:  AIRFLOW__CORE__XCOM_BACKEND
           value: "astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend"
 

--- a/locals.tf
+++ b/locals.tf
@@ -120,7 +120,7 @@ locals {
         gitSync = {
           enabled      = true
           repo         = "git@github.com:GersonRS/airflow-dags.git"
-          branch       = var.target_revision == "develop" ? develop : "main"
+          branch       = var.target_revision == "develop" ? "develop" : "main"
           rev          = "HEAD"
           depth        = 2
           maxFailures  = 2

--- a/locals.tf
+++ b/locals.tf
@@ -120,7 +120,7 @@ locals {
         gitSync = {
           enabled      = true
           repo         = "git@github.com:GersonRS/airflow-dags.git"
-          branch       = "main"
+          branch       = var.target_revision == "develop" ? develop : "main"
           rev          = "HEAD"
           depth        = 2
           maxFailures  = 2

--- a/locals.tf
+++ b/locals.tf
@@ -76,23 +76,7 @@ locals {
       #   enabled = false
       # }
       ingress = {
-        enabled = true
-        web = {
-          enabled = true
-          annotations = {
-            "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
-            "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-            "traefik.ingress.kubernetes.io/router.tls"         = "true"
-          }
-          hosts = [{
-            name = local.domain_full
-            tls = {
-              enabled    = true
-              secretName = "airflow-tls-ingress"
-            }
-          }]
-          ingressClassName = "traefik"
-        }
+        enabled = false
       }
       pgbouncer = {
         enabled = true
@@ -267,6 +251,7 @@ locals {
                 "Viewer": ["Viewer"],
                 "Admin": ["Admin"],
                 "User": ["User"],
+                "Op": ["Op"],
             }
 
             OAUTH_PROVIDERS = [{
@@ -290,12 +275,14 @@ locals {
             }]
             def map_roles(team_list):
                 team_role_map = {
-                    "modern-gitops-stack-viewer": AUTH_ROLE_VIEWER,
                     "modern-gitops-stack-admins": AUTH_ROLE_ADMIN,
-                    "modern-gitops-stack-public": AUTH_ROLE_PUBLIC,
-                    "modern-gitops-stack-user": AUTH_ROLE_USER,
+                    "modern-gitops-stack-editors": "Op",
+                    "modern-gitops-stack-data-engineers": "Op",
+                    "modern-gitops-stack-ml-engineers": "User",
+                    "modern-gitops-stack-data-scientists": "User",
+                    "modern-gitops-stack-viewers": AUTH_ROLE_VIEWER,
                 }
-                return list(set(team_role_map.get(team, AUTH_ROLE_VIEWER) for team in team_list))
+                return list(set(team_role_map[team] for team in team_list if team in team_role_map))
             class CustomSecurityManager(AirflowSecurityManager):
                 def get_oauth_user_info(self, provider, resp):
                     me = self.oauth_remotes[provider].get("openid-connect/userinfo")
@@ -307,7 +294,7 @@ locals {
                     groups = map_roles(data.get("groups", []))
 
                     if groups is None or len(groups) < 1:
-                        groups = ["User"]
+                        groups = [AUTH_ROLE_PUBLIC]
 
                     log.info("User groups info: %s", groups)
                     return {
@@ -406,6 +393,17 @@ locals {
       #   - secretRef:
       #       name: "airflow-airflow-connections"
       # EOT
+    }
+  }]
+
+  helm_values_httproute = [{
+    httproute = {
+      enabled           = true
+      host              = local.domain
+      gateway_name      = var.gateway_name
+      gateway_namespace = var.gateway_namespace
+      backend_service   = "airflow-webserver"
+      backend_port      = 8080
     }
   }]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -119,7 +119,7 @@ locals {
       dags = {
         gitSync = {
           enabled      = true
-          repo         = "git@github.com:GersonRS/hands-on-github-actions-part-two.git"
+          repo         = "git@github.com:GersonRS/airflow-dags.git"
           branch       = var.target_revision == "develop" ? "develop" : "main"
           rev          = "HEAD"
           depth        = 2

--- a/locals.tf
+++ b/locals.tf
@@ -41,7 +41,7 @@ locals {
       images = {
         airflow = {
           repository = "gersonrs/airflow"
-          tag        = "v1.5.1"
+          tag        = "v1.5.3"
         }
       }
       volumes = [

--- a/locals.tf
+++ b/locals.tf
@@ -41,7 +41,7 @@ locals {
       images = {
         airflow = {
           repository = "gersonrs/airflow"
-          tag        = "v1.5.3"
+          tag        = "v1.5.4"
         }
       }
       volumes = [

--- a/locals.tf
+++ b/locals.tf
@@ -119,7 +119,7 @@ locals {
       dags = {
         gitSync = {
           enabled      = true
-          repo         = "git@github.com:GersonRS/airflow-dags.git"
+          repo         = "git@github.com:GersonRS/hands-on-github-actions-part-two.git"
           branch       = var.target_revision == "develop" ? "develop" : "main"
           rev          = "HEAD"
           depth        = 2

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "argocd_project" "this" {
 }
 
 data "utils_deep_merge_yaml" "values" {
-  input = [for i in concat(local.helm_values, var.helm_values) : yamlencode(i)]
+  input = [for i in concat(local.helm_values, local.helm_values_httproute, var.helm_values) : yamlencode(i)]
 }
 
 resource "argocd_application" "this" {

--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,9 @@ resource "random_password" "airflow_webserver_secret_key" {
 resource "kubernetes_namespace" "airflow_namespace" {
   metadata {
     annotations = {
-      name = "airflow"
+      name = var.namespace
     }
-    name = "airflow"
+    name = var.namespace
   }
   depends_on = [
     resource.null_resource.dependencies,

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "kubernetes_namespace" "airflow_namespace" {
 resource "kubernetes_secret" "airflow_ssh_secret" {
   metadata {
     name      = "airflow-ssh-secret"
-    namespace = "airflow"
+    namespace = var.namespace
   }
 
   data = {
@@ -39,19 +39,19 @@ resource "argocd_project" "this" {
 
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "airflow-${var.destination_cluster}" : "airflow"
-    namespace = "argocd"
+    namespace = var.argocd_namespace
     annotations = {
-      "modern-gitops-stack.io/argocd_namespace" = "argocd"
+      "modern-gitops-stack.io/argocd_namespace" = var.argocd_namespace
     }
   }
 
   spec {
     description  = "Airflow application project for cluster ${var.destination_cluster}"
-    source_repos = ["https://github.com/GersonRS/modern-gitops-stack-module-airflow.git"]
+    source_repos = [var.project_source_repo]
 
     destination {
       name      = var.destination_cluster
-      namespace = "airflow"
+      namespace = var.namespace
     }
 
     orphaned_resources {
@@ -72,7 +72,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "airflow-${var.destination_cluster}" : "airflow"
-    namespace = "argocd"
+    namespace = var.argocd_namespace
     labels = merge({
       "application" = "airflow"
       "cluster"     = var.destination_cluster
@@ -90,7 +90,7 @@ resource "argocd_application" "this" {
     project = var.argocd_project == null ? argocd_project.this[0].metadata.0.name : var.argocd_project
 
     source {
-      repo_url        = "https://github.com/GersonRS/modern-gitops-stack-module-airflow.git"
+      repo_url        = var.project_source_repo
       path            = "charts/airflow"
       target_revision = var.target_revision
       helm {
@@ -100,7 +100,7 @@ resource "argocd_application" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = "airflow"
+      namespace = var.namespace
     }
 
     sync_policy {

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2"
+      version = ">= 2"
     }
     argocd = {
       source  = "argoproj-labs/argocd"

--- a/variables.tf
+++ b/variables.tf
@@ -178,3 +178,15 @@ variable "gitsync" {
     branch = "main"
   }
 }
+
+variable "gateway_name" {
+  description = "Name of the Istio Gateway resource to attach HTTPRoutes to."
+  type        = string
+  default     = "istio-gateway"
+}
+
+variable "gateway_namespace" {
+  description = "Namespace where the Istio Gateway resource is deployed."
+  type        = string
+  default     = "istio-ingress"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,24 @@
 ## Standard variables
 #######################
 
+variable "project_source_repo" {
+  description = "Repository allowed to be scraped in this AppProject."
+  type        = string
+  default     = "https://github.com/GersonRS/modern-gitops-stack-module-airflow.git"
+}
+
+variable "namespace" {
+  description = "Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist."
+  type        = string
+  default     = "orchestrator"
+}
+
+variable "argocd_namespace" {
+  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
+  type        = string
+  default     = "argocd"
+}
+
 variable "cluster_name" {
   description = "Name given to the cluster. Value used for naming some the resources created by the module."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -166,3 +166,15 @@ variable "home_ssh" {
   type        = string
   default     = "/home/gerson/.ssh/id_ed25519" # change here
 }
+
+variable "gitsync" {
+  description = "gitsync configuration"
+  type = object({
+    repo   = string
+    branch = string
+  })
+  default = {
+    repo   = "git@github.com:GersonRS/airflow-dags.git"
+    branch = var.target_revision == "develop" ? "develop" : "main"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -175,6 +175,6 @@ variable "gitsync" {
   })
   default = {
     repo   = "git@github.com:GersonRS/airflow-dags.git"
-    branch = var.target_revision == "develop" ? "develop" : "main"
+    branch = "main"
   }
 }


### PR DESCRIPTION
## Changes

- Migrate ingress from Traefik IngressRoute to Istio Gateway API HTTPRoute
- Fix OIDC group role mapping (`role_attribute_path`)
- Relax helm provider constraint to `>= 2` to allow v3
- Add `gateway_name` and `gateway_namespace` variables